### PR TITLE
Add Telegram interface for TRIPD

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 torch==2.2.1+cpu
 transformers==4.38.2
+python-telegram-bot==20.7

--- a/tripd.py
+++ b/tripd.py
@@ -87,5 +87,20 @@ class TripDModel:
             train_async()
         return script
 
+    # ------------------------------------------------------------------
+    def generate_from_section(self, section: str) -> str:
+        """Create a TRIPD script using commands from a specific section."""
+        if section not in self.sections:
+            raise KeyError(f"Unknown section: {section}")
+        commands = random.sample(self.sections[section], 4)
+        extra = random.sample(self.extra_verbs, max(1, len(commands) // 5))
+        lines = [f"    {cmd}" for cmd in commands + extra]
+        script = "def tripd_script():\n" + "\n".join(lines) + "\n"
+
+        log_script(script)
+        if get_log_count() % 5 == 0:
+            train_async()
+        return script
+
 
 __all__ = ["TripDModel"]

--- a/tripd_tg.py
+++ b/tripd_tg.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+"""Telegram interface for the TRIPD model."""
+
+from pathlib import Path
+import os
+from typing import List
+
+from telegram import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    Update,
+    BotCommand,
+)
+from telegram.ext import (
+    Application,
+    CallbackQueryHandler,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
+
+from .tripd import TripDModel
+
+# ---------------------------------------------------------------------------
+# Model and dictionary setup
+_model = TripDModel()
+_sections: List[str] = sorted(_model.sections)
+
+# Preload README and split into three equal parts
+_README = Path(__file__).resolve().parent / "README.md"
+_text = _README.read_text(encoding="utf-8")
+_chunk = len(_text) // 3
+_readme_parts = [
+    _text[i * _chunk : (i + 1) * _chunk] for i in range(3)
+]
+_readme_parts[2] += _text[3 * _chunk :]
+
+# ---------------------------------------------------------------------------
+# Menu helpers
+
+def _menu_keyboard() -> InlineKeyboardMarkup:
+    buttons = [[InlineKeyboardButton(name, callback_data=f"section:{name}")]
+               for name in _sections]
+    buttons.append([InlineKeyboardButton("THEORY", callback_data="theory:0")])
+    return InlineKeyboardMarkup(buttons)
+
+
+async def _show_menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if update.callback_query:
+        await update.callback_query.answer()
+        await update.callback_query.edit_message_text(
+            "Select a topic:", reply_markup=_menu_keyboard()
+        )
+    else:
+        await update.message.reply_text(
+            "Select a topic:", reply_markup=_menu_keyboard()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Section handling
+async def _send_section(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    section = query.data.split(":", 1)[1]
+    script = _model.generate_from_section(section)
+    await query.edit_message_text(
+        f"```python\n{script}\n```", parse_mode="Markdown"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Theory navigation
+async def _send_theory(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    index = int(query.data.split(":", 1)[1])
+    text = _readme_parts[index]
+    buttons = []
+    if index > 0:
+        buttons.append(
+            InlineKeyboardButton("Back", callback_data=f"theory:{index - 1}")
+        )
+    else:
+        buttons.append(InlineKeyboardButton("Back", callback_data="menu"))
+    if index < 2:
+        buttons.append(
+            InlineKeyboardButton("Forward", callback_data=f"theory:{index + 1}")
+        )
+    else:
+        buttons.append(InlineKeyboardButton("Forward", callback_data="menu"))
+    await query.edit_message_text(
+        text, reply_markup=InlineKeyboardMarkup([buttons])
+    )
+
+
+# ---------------------------------------------------------------------------
+# Message echo with metric-based font selection
+async def _handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    assert update.message
+    text = update.message.text or ""
+    metrics = _model._metrics(text)
+    if metrics["entropy"] > 4.5:
+        formatted = f"<b>{text}</b>"
+    elif metrics["perplexity"] > 10:
+        formatted = f"<i>{text}</i>"
+    else:
+        formatted = f"<code>{text}</code>"
+    await update.message.reply_text(formatted, parse_mode="HTML")
+
+
+# ---------------------------------------------------------------------------
+async def _post_init(app: Application) -> None:
+    await app.bot.set_my_commands([BotCommand("tripd", "Open TRIPD menu")])
+
+
+def main() -> None:
+    token = os.environ.get("TELEGRAM_TOKEN")
+    if not token:
+        raise RuntimeError("TELEGRAM_TOKEN environment variable is required")
+    application = (
+        Application.builder()
+        .token(token)
+        .post_init(_post_init)
+        .build()
+    )
+    application.add_handler(CommandHandler("tripd", _show_menu))
+    application.add_handler(CallbackQueryHandler(_show_menu, pattern="^menu$"))
+    application.add_handler(
+        CallbackQueryHandler(_send_section, pattern="^section:")
+    )
+    application.add_handler(
+        CallbackQueryHandler(_send_theory, pattern="^theory:")
+    )
+    application.add_handler(
+        MessageHandler(filters.TEXT & ~filters.COMMAND, _handle_message)
+    )
+    application.run_polling()
+
+
+__all__ = ["main"]


### PR DESCRIPTION
## Summary
- Extend TripDModel with ability to generate scripts from explicit sections
- Implement `tripd_tg` Telegram bot exposing dictionary topics and theory reader
- Add python-telegram-bot dependency

## Testing
- `python -m py_compile tripd.py tripd_tg.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4170e0dd4832989b8e2fb17929121