### PR TITLE
Expose TripDModel metrics and update Telegram bot

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,30 @@
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+BASE = Path(__file__).resolve().parent.parent
+
+
+def _load(name: str, file: str):
+    spec = importlib.util.spec_from_file_location(name, BASE / file)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+# Load modules under a package name to satisfy relative imports
+_load("tripd_pkg.tripd_memory", "tripd_memory.py")
+_load("tripd_pkg.tripd_expansion", "tripd_expansion.py")
+tripd = _load("tripd_pkg.tripd", "tripd.py")
+TripDModel = tripd.TripDModel
+
+
+def test_public_metrics():
+    model = TripDModel()
+    metrics = model.metrics("abc")
+    assert metrics["entropy"] == pytest.approx(math.log2(3), abs=1e-12)
+    assert metrics["perplexity"] == pytest.approx(3.0, abs=1e-12)
+    assert metrics["resonance"] == pytest.approx(0.0, abs=1e-12)

--- a/tripd.py
+++ b/tripd.py
@@ -63,6 +63,11 @@ class TripDModel:
         }
 
     # ------------------------------------------------------------------
+    def metrics(self, text: str) -> Dict[str, float]:
+        """Public wrapper around the internal metrics calculator."""
+        return self._metrics(text)
+
+    # ------------------------------------------------------------------
     def _choose_section(self, metrics: Dict[str, float]) -> str:
         names = sorted(self.sections)
         index_value = (
@@ -75,7 +80,7 @@ class TripDModel:
 
     # ------------------------------------------------------------------
     def generate_script(self, message: str) -> str:
-        metrics = self._metrics(message)
+        metrics = self.metrics(message)
         section = self._choose_section(metrics)
         commands = random.sample(self.sections[section], 4)
         extra = random.sample(self.extra_verbs, max(1, len(commands) // 5))

--- a/tripd_tg.py
+++ b/tripd_tg.py
@@ -101,7 +101,7 @@ async def _send_theory(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 async def _handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     assert update.message
     text = update.message.text or ""
-    metrics = _model._metrics(text)
+    metrics = _model.metrics(text)
     if metrics["entropy"] > 4.5:
         formatted = f"<b>{text}</b>"
     elif metrics["perplexity"] > 10:


### PR DESCRIPTION
## Summary
- Add public `metrics` wrapper in `TripDModel`
- Update Telegram handler to use `TripDModel.metrics`
- Add test for public metrics

## Testing
- `ruff check tripd.py tripd_tg.py tests/test_metrics.py --ignore=E402`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b41cf68b688329988c4966b0ca478e