### PR TITLE
Handle small dictionary sections in script generation

### DIFF
--- a/tests/test_small_sections.py
+++ b/tests/test_small_sections.py
@@ -1,0 +1,43 @@
+import importlib.util
+import sys
+import random
+from pathlib import Path
+
+import pytest
+
+BASE = Path(__file__).resolve().parent.parent
+
+def _load(name: str, file: str):
+    spec = importlib.util.spec_from_file_location(name, BASE / file)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+memory = _load("tripd_pkg.tripd_memory", "tripd_memory.py")
+expansion = _load("tripd_pkg.tripd_expansion", "tripd_expansion.py")
+tripd = _load("tripd_pkg.tripd", "tripd.py")
+TripDModel = tripd.TripDModel
+
+
+@pytest.mark.parametrize("num_cmds", [1, 2, 3])
+def test_generate_from_small_section(tmp_path, num_cmds):
+    memory._LOG_PATH = tmp_path / "scripts.log"
+    expansion._TRAIN_LOG = tmp_path / "train.log"
+    dictionary = "## small\n" + "\n".join(f"cmd{i}()" for i in range(num_cmds))
+    dictionary += "\n\n## pool\n" + "\n".join(f"pool{i}()" for i in range(4)) + "\n"
+    path = tmp_path / "dict.md"
+    path.write_text(dictionary)
+
+    model = TripDModel(path)
+    random.seed(0)
+    script = model.generate_from_section("small")
+    lines = [line.strip() for line in script.splitlines()[1:] if line.strip()]
+    extra_set = set(model.extra_verbs)
+    commands = [line for line in lines if line not in extra_set]
+
+    assert len(commands) == 4
+    for i in range(num_cmds):
+        assert f"cmd{i}()" in commands
+    if num_cmds < 4:
+        assert any(f"pool{i}()" in commands for i in range(4))

--- a/tripd.py
+++ b/tripd.py
@@ -25,6 +25,9 @@ class TripDModel:
         base = Path(__file__).resolve().parent
         path = dictionary_path or base / "tripdictionary.md"
         self.sections = self._load_dictionary(path)
+        self.all_commands = [
+            cmd for cmds in self.sections.values() for cmd in cmds
+        ]
         self.extra_verbs = [
             "wander_verse()",
             "spark_improv()",
@@ -82,7 +85,11 @@ class TripDModel:
     def generate_script(self, message: str) -> str:
         metrics = self.metrics(message)
         section = self._choose_section(metrics)
-        commands = random.sample(self.sections[section], 4)
+        k = min(4, len(self.sections[section]))
+        commands = random.sample(self.sections[section], k)
+        if k < 4:
+            pool = [cmd for cmd in self.all_commands if cmd not in commands]
+            commands += random.sample(pool, 4 - k)
         extra = random.sample(self.extra_verbs, max(1, len(commands) // 5))
         lines = [f"    {cmd}" for cmd in commands + extra]
         script = "def tripd_script():\n" + "\n".join(lines) + "\n"
@@ -97,7 +104,11 @@ class TripDModel:
         """Create a TRIPD script using commands from a specific section."""
         if section not in self.sections:
             raise KeyError(f"Unknown section: {section}")
-        commands = random.sample(self.sections[section], 4)
+        k = min(4, len(self.sections[section]))
+        commands = random.sample(self.sections[section], k)
+        if k < 4:
+            pool = [cmd for cmd in self.all_commands if cmd not in commands]
+            commands += random.sample(pool, 4 - k)
         extra = random.sample(self.extra_verbs, max(1, len(commands) // 5))
         lines = [f"    {cmd}" for cmd in commands + extra]
         script = "def tripd_script():\n" + "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- Ensure script generation uses up to four commands, filling from the global pool when a section is undersized
- Record all dictionary commands for backfilling
- Add parameterized tests for sections containing 1–3 commands

## Testing
- `ruff check .` *(fails: E402 Module level import not at top of file)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b41e61696083298812dfe50bc90a74