### PR TITLE
Log training sessions with timestamps and counts

### DIFF
--- a/tests/test_expansion_log.py
+++ b/tests/test_expansion_log.py
@@ -1,0 +1,35 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+BASE = Path(__file__).resolve().parent.parent
+
+
+def _load(name: str, file: str):
+    spec = importlib.util.spec_from_file_location(name, BASE / file)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# Load memory first to satisfy expansion's relative import
+_load("tripd_pkg.tripd_memory", "tripd_memory.py")
+expansion = _load("tripd_pkg.tripd_expansion", "tripd_expansion.py")
+
+
+def test_training_log_accumulates(monkeypatch, tmp_path):
+    log_path = tmp_path / "train.log"
+    monkeypatch.setattr(expansion, "_TRAIN_LOG", log_path)
+
+    expansion._train_on_scripts(["a"])
+    expansion._train_on_scripts(["b", "c"])
+
+    lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+
+    t1, c1 = lines[0].split("\t")
+    t2, c2 = lines[1].split("\t")
+    assert int(c1) == 1
+    assert int(c2) == 2
+    assert int(t2) >= int(t1)

--- a/tripd_expansion.py
+++ b/tripd_expansion.py
@@ -1,11 +1,11 @@
-from __future__ import annotations
-
 """Asynchronous model expansion utilities for TRIPD.
 
 The real project would fine‑tune a transformer on collected scripts.
 For demonstration purposes we simply record when a training event would
 occur and run the task in a background thread.
 """
+
+from __future__ import annotations
 
 from pathlib import Path
 from threading import Thread
@@ -20,11 +20,11 @@ _TRAIN_LOG = Path(__file__).resolve().parent / "training.log"
 def _train_on_scripts(scripts: Iterable[str]) -> None:
     """Pretend to fine‑tune a model on the provided scripts."""
     # A realistic implementation would invoke torch/transformers here.
+    scripts = list(scripts)
     time.sleep(0.1)  # Simulate a bit of work.
-    _TRAIN_LOG.write_text(
-        f"trained_on={len(list(scripts))}\n",
-        encoding="utf-8",
-    )
+    timestamp = int(time.time())
+    with open(_TRAIN_LOG, "a", encoding="utf-8") as fh:
+        fh.write(f"{timestamp}\t{len(scripts)}\n")
 
 
 def train_async() -> None:


### PR DESCRIPTION
## Summary
- Append training sessions to `training.log` with timestamps and example counts
- Test that multiple training runs accumulate entries in the log

## Testing
- `ruff check tripd_expansion.py tests/test_expansion_log.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b41f2c98c88329be563cc40e05a055