### PR TITLE
Fix resonance metric and expand test coverage

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -27,4 +27,11 @@ def test_public_metrics():
     metrics = model.metrics("abc")
     assert metrics["entropy"] == pytest.approx(math.log2(3), abs=1e-12)
     assert metrics["perplexity"] == pytest.approx(3.0, abs=1e-12)
-    assert metrics["resonance"] == pytest.approx(0.0, abs=1e-12)
+    assert metrics["resonance"] == pytest.approx(0.294, abs=1e-12)
+
+
+def test_resonance_differs_for_texts():
+    model = TripDModel()
+    r1 = model.metrics("abc")["resonance"]
+    r2 = model.metrics("abd")["resonance"]
+    assert r1 != r2

--- a/tripd.py
+++ b/tripd.py
@@ -1,12 +1,12 @@
-from __future__ import annotations
-
 """Core TRIPD model built on a lightweight transformer.
 
 The model loads the TRIPD dictionary and compose scripts in the
-TRIPD dialect.  Metrics derived from the input message influence which
-section of the dictionary is sampled.  Twenty percent of the commands come
+TRIPD dialect. Metrics derived from the input message influence which
+section of the dictionary is sampled. Twenty percent of the commands come
 from an internal pool to encourage semantic drift.
 """
+
+from __future__ import annotations
 
 from collections import Counter
 from pathlib import Path
@@ -58,7 +58,7 @@ class TripDModel:
         probs = [c / total for c in counts.values()]
         entropy = -sum(p * math.log2(p) for p in probs)
         perplexity = 2**entropy
-        resonance = sum(ord(ch) for ch in text) % 1
+        resonance = (sum(ord(ch) for ch in text) % 1000) / 1000
         return {
             "entropy": entropy,
             "perplexity": perplexity,


### PR DESCRIPTION
## Summary
- compute resonance as fractional value instead of always zero
- verify resonance changes for different texts
- reposition module docstring and imports for linter compliance

## Testing
- `ruff check tripd.py tests/test_metrics.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b422500ab48329b8cd56fb2ee99793