### PR TITLE
Add fractal spectral metric for section selection

### DIFF
--- a/tests/test_fractal_mode.py
+++ b/tests/test_fractal_mode.py
@@ -1,0 +1,36 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+BASE = Path(__file__).resolve().parent.parent
+
+
+def _load(name: str, file: str):
+    spec = importlib.util.spec_from_file_location(name, BASE / file)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+_load("tripd_pkg.tripd_memory", "tripd_memory.py")
+_load("tripd_pkg.tripd_expansion", "tripd_expansion.py")
+tripd = _load("tripd_pkg.tripd", "tripd.py")
+TripDModel = tripd.TripDModel
+
+
+def test_selector_differs_between_modes():
+    text = "fractal energy"
+    deterministic = TripDModel()
+    fractal = TripDModel(fractal_metrics=True)
+    sel_det = deterministic.metrics(text)["selector"]
+    sel_frac = fractal.metrics(text)["selector"]
+    assert sel_det != sel_frac
+
+
+def test_section_differs_between_modes():
+    text = "fractal energy"
+    deterministic = TripDModel()
+    fractal = TripDModel(fractal_metrics=True)
+    sec_det = deterministic._choose_section(deterministic.metrics(text))
+    sec_frac = fractal._choose_section(fractal.metrics(text))
+    assert sec_det != sec_frac


### PR DESCRIPTION
## Summary
- extend TripDModel metrics with optional fractal spectral analysis and selector output
- choose dictionary section using selector metric
- cover deterministic vs. fractal behavior in new tests

## Testing
- `python -m py_compile tripd.py tests/test_fractal_mode.py tests/test_metrics.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b42594375c8329b1a72a742054ed9b