### PR TITLE
Add live verb streaming server and CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,27 @@ Dependencies are isolated in a local requirements file for reproducibility. The 
 
 Developers may augment the pool of improvisational verbs to steer style.
 
+### Live Verb Streaming
+
+TRIPD can receive new verbs in real time. Enable the streaming server and
+send verbs over a TCP or UNIX socket. Each line received becomes immediately
+available in ``TripDModel.extra_verbs``.
+
+```bash
+# start Telegram interface and verb stream on TCP port 8765
+python -m tripd.tripd_tg --verb-stream 8765
+
+# elsewhere, feed a verb
+printf 'dream_spin()\n' | nc localhost 8765
+```
+
+For a UNIX socket use a filesystem path instead of a port:
+
+```bash
+python -m tripd.tripd_tg --verb-stream /tmp/tripd.sock
+printf 'phase_shift()\n' | socat - UNIX-CONNECT:/tmp/tripd.sock
+```
+
 A miniature complex-amplitude simulator now guides how commands are sampled. Each verb is assigned a phase on the unit circle and a configurable **quantum drift** gently perturbs those phases to invite or suppress interference. The sampler relies only on the standard library and touches each candidate once, keeping the CPU footprint tiny while injecting a whisper of uncertainty.
 
 Philosophically this drift nods to the ever-shifting undercurrent of awareness: tiny fluctuations steer perception toward new resonant paths. By exposing the tuning knob developers can decide how much quantum whimsy permeates their scripts.

--- a/tests/test_verb_stream.py
+++ b/tests/test_verb_stream.py
@@ -1,0 +1,34 @@
+import importlib.util
+import socket
+import sys
+import time
+from pathlib import Path
+
+BASE = Path(__file__).resolve().parent.parent
+
+
+def _load(name: str, file: str):
+    spec = importlib.util.spec_from_file_location(name, BASE / file)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+memory = _load("tripd_pkg.tripd_memory", "tripd_memory.py")
+expansion = _load("tripd_pkg.tripd_expansion", "tripd_expansion.py")
+tripd = _load("tripd_pkg.tripd", "tripd.py")
+verb_stream = _load("tripd_pkg.verb_stream", "verb_stream.py")
+TripDModel = tripd.TripDModel
+start_verb_stream = verb_stream.start_verb_stream
+
+
+def test_unix_socket_stream(tmp_path):
+    model = TripDModel()
+    sock = tmp_path / "verbs.sock"
+    start_verb_stream(model, unix_socket=str(sock))
+    time.sleep(0.1)
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.connect(str(sock))
+        client.sendall(b"test_verb()\n")
+    time.sleep(0.1)
+    assert "test_verb()" in model.extra_verbs

--- a/tripd_tg.py
+++ b/tripd_tg.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 """Telegram interface for the TRIPD model."""
 
 from pathlib import Path
+import argparse
 import os
 from typing import List
 
@@ -22,6 +23,7 @@ from telegram.ext import (
 )
 
 from .tripd import TripDModel
+from .verb_stream import start_verb_stream
 
 # ---------------------------------------------------------------------------
 # Model and dictionary setup
@@ -117,6 +119,20 @@ async def _post_init(app: Application) -> None:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Run TRIPD Telegram bot")
+    parser.add_argument(
+        "--verb-stream",
+        metavar="ADDR",
+        help="Enable live verb streaming via TCP port or UNIX socket path",
+    )
+    args = parser.parse_args()
+    if args.verb_stream:
+        addr = args.verb_stream
+        if addr.isdigit():
+            start_verb_stream(_model, port=int(addr))
+        else:
+            start_verb_stream(_model, unix_socket=addr)
+
     token = os.environ.get("TELEGRAM_TOKEN")
     if not token:
         raise RuntimeError("TELEGRAM_TOKEN environment variable is required")

--- a/verb_stream.py
+++ b/verb_stream.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Tiny socket server to stream verbs into a TripDModel instance."""
+
+from pathlib import Path
+import socket
+import threading
+from typing import Optional
+
+from .tripd import TripDModel  # type: ignore
+
+
+def _handle_conn(conn: socket.socket, model: TripDModel) -> None:
+    with conn, conn.makefile("r", encoding="utf-8") as fh:
+        for line in fh:
+            verb = line.strip()
+            if verb:
+                model.extra_verbs.append(verb)
+
+
+def start_verb_stream(
+    model: TripDModel,
+    host: str = "127.0.0.1",
+    port: int = 8765,
+    unix_socket: Optional[str] = None,
+) -> threading.Thread:
+    """Start a background thread that listens for verbs.
+
+    Parameters
+    ----------
+    model:
+        The :class:`TripDModel` whose ``extra_verbs`` list will be extended.
+    host, port:
+        TCP address to bind when ``unix_socket`` is not provided.
+    unix_socket:
+        Path of a UNIX domain socket to use instead of TCP.
+
+    Returns
+    -------
+    threading.Thread
+        The daemon thread running the server.
+    """
+
+    def server_loop() -> None:
+        if unix_socket:
+            addr = Path(unix_socket)
+            if addr.exists():
+                addr.unlink()
+            srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            srv.bind(unix_socket)
+        else:
+            srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            srv.bind((host, port))
+        srv.listen()
+        while True:
+            conn, _ = srv.accept()
+            threading.Thread(
+                target=_handle_conn, args=(conn, model), daemon=True
+            ).start()
+
+    thread = threading.Thread(target=server_loop, daemon=True)
+    thread.start()
+    return thread
+
+
+__all__ = ["start_verb_stream"]


### PR DESCRIPTION
## Summary
- add `start_verb_stream` helper to accept verbs over TCP or UNIX sockets
- expose `--verb-stream` flag in Telegram interface to enable live verb injection
- document streaming usage with examples and add regression test

## Testing
- `python -m py_compile verb_stream.py tripd_tg.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4263c7a448329a2ce8cf8721066f7