### PR TITLE
Log timestamps for expansion training runs

### DIFF
--- a/tests/test_expansion_log.py
+++ b/tests/test_expansion_log.py
@@ -1,5 +1,6 @@
 import importlib.util
 import sys
+from datetime import datetime
 from pathlib import Path
 
 BASE = Path(__file__).resolve().parent.parent
@@ -32,4 +33,6 @@ def test_training_log_accumulates(monkeypatch, tmp_path):
     t2, c2 = lines[1].split("\t")
     assert int(c1) == 1
     assert int(c2) == 2
-    assert int(t2) >= int(t1)
+    dt1 = datetime.fromisoformat(t1)
+    dt2 = datetime.fromisoformat(t2)
+    assert dt2 >= dt1

--- a/tripd_expansion.py
+++ b/tripd_expansion.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 from threading import Thread
 from typing import Iterable
+from datetime import datetime
 import time
 
 from .tripd_memory import load_scripts
@@ -22,8 +23,8 @@ def _train_on_scripts(scripts: Iterable[str]) -> None:
     # A realistic implementation would invoke torch/transformers here.
     scripts = list(scripts)
     time.sleep(0.1)  # Simulate a bit of work.
-    timestamp = int(time.time())
-    with open(_TRAIN_LOG, "a", encoding="utf-8") as fh:
+    timestamp = datetime.now().isoformat()
+    with _TRAIN_LOG.open("a", encoding="utf-8") as fh:
         fh.write(f"{timestamp}\t{len(scripts)}\n")
 
 


### PR DESCRIPTION
## Summary
- append training log entries using Path.open
- record ISO-formatted datetime for each training event
- update expansion log test for new timestamp format

## Testing
- `python -m flake8 tripd_expansion.py tests/test_expansion_log.py` *(fails: No module named flake8)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b428b6e3408329aedbe90debe42ba9