### PR TITLE
feat: add script log cache and rotation

### DIFF
--- a/tests/test_log_rotation.py
+++ b/tests/test_log_rotation.py
@@ -1,0 +1,33 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+BASE = Path(__file__).resolve().parent.parent
+
+
+def _load(name: str, file: str):
+    spec = importlib.util.spec_from_file_location(name, BASE / file)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_log_rotation(monkeypatch, tmp_path):
+    memory = _load("tripd_pkg.tripd_memory", "tripd_memory.py")
+    log_path = tmp_path / "scripts.log"
+    monkeypatch.setattr(memory, "_LOG_PATH", log_path)
+    monkeypatch.setattr(memory, "_LOG_MAX_BYTES", 100)
+    memory._SCRIPTS_INDEX.clear()
+    memory._SCRIPT_LIST.clear()
+    memory._CACHE_LOADED = False
+    memory._load_cache()
+
+    for i in range(20):
+        memory.log_script(f"script_{i}")
+
+    rotated = log_path.with_suffix(log_path.suffix + ".1")
+    assert rotated.exists()
+    assert log_path.exists()
+    assert any("script_19" in line for line in log_path.read_text().splitlines())

--- a/tripd_memory.py
+++ b/tripd_memory.py
@@ -9,21 +9,43 @@ been collected.
 """
 
 from pathlib import Path
+import hashlib
 import json
 from typing import List, Set
 
 _LOG_PATH = Path(__file__).resolve().parent / "scripts.log"
+_LOG_MAX_BYTES = 5_000_000  # Rotate at ~5MB to avoid runaway growth.
 
-# In-memory cache of previously seen scripts.  It is populated once when the
-# module is imported and then kept in sync as new scripts are logged.
+# In-memory cache of previously seen script hashes and their original text.
+# The cache is populated once when the module is imported and then kept in
+# sync as new scripts are logged.
 _SCRIPTS_INDEX: Set[str] = set()
+_SCRIPT_LIST: List[str] = []
 _CACHE_LOADED = False
+
+
+def _hash_script(script: str) -> str:
+    """Return a stable hash for *script* used for fast lookups."""
+    return hashlib.sha256(script.encode("utf-8")).hexdigest()
 
 
 def _ensure_log() -> None:
     """Create the log file if it does not yet exist."""
     if not _LOG_PATH.exists():
         _LOG_PATH.touch()
+
+
+def _rotate_log() -> None:
+    """Rotate the log file if it exceeds the configured size limit."""
+    if not _LOG_PATH.exists():
+        return
+    if _LOG_PATH.stat().st_size <= _LOG_MAX_BYTES:
+        return
+    backup = _LOG_PATH.with_suffix(_LOG_PATH.suffix + ".1")
+    if backup.exists():
+        backup.unlink()
+    _LOG_PATH.rename(backup)
+    _LOG_PATH.touch()
 
 
 def _load_cache() -> None:
@@ -38,7 +60,10 @@ def _load_cache() -> None:
             if not line:
                 continue
             try:
-                _SCRIPTS_INDEX.add(json.loads(line)["script"])
+                data = json.loads(line)
+                script = data.get("script", "")
+                _SCRIPT_LIST.append(script)
+                _SCRIPTS_INDEX.add(data.get("hash") or _hash_script(script))
             except Exception:
                 # Ignore malformed lines while keeping the log readable.
                 continue
@@ -48,18 +73,21 @@ def _load_cache() -> None:
 def load_scripts() -> List[str]:
     """Return a list of all previously generated scripts."""
     _load_cache()
-    return list(_SCRIPTS_INDEX)
+    return list(_SCRIPT_LIST)
 
 
 def log_script(script: str) -> None:
     """Persist a script if it has not been seen before."""
     _load_cache()
-    if script in _SCRIPTS_INDEX:
+    script_hash = _hash_script(script)
+    if script_hash in _SCRIPTS_INDEX:
         return
     _ensure_log()
+    _rotate_log()
     with _LOG_PATH.open("a", encoding="utf-8") as fh:
-        fh.write(json.dumps({"script": script}) + "\n")
-    _SCRIPTS_INDEX.add(script)
+        fh.write(json.dumps({"hash": script_hash, "script": script}) + "\n")
+    _SCRIPTS_INDEX.add(script_hash)
+    _SCRIPT_LIST.append(script)
 
 
 def get_log_count() -> int:


### PR DESCRIPTION
## Summary
- hash and cache logged scripts in memory
- rotate `scripts.log` once it grows beyond 5MB
- add regression test for log rotation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b43235589c83299f156fa925199bc3