### PR TITLE
Remove torch dependency for CPU-only operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ On startup the model reads this dictionary to form its initial phrase repertoire
 
 Generated scripts conform to Python syntax while carrying tripd's surreal verbs. The memory module ensures that a script is never produced twice. Logged outputs accumulate as JSON lines for transparent review. After every five unique scripts the system triggers a background training pass.
 
-Training is asynchronous so user interaction remains responsive. The expansion module currently simulates fine-tuning and records its activity. A real deployment could swap this stub for a torch-based trainer.
+Training is asynchronous so user interaction remains responsive. The expansion module currently simulates fine-tuning and records its activity. A real deployment could integrate a lightweight trainer if deeper learning is desired.
 
-Dependencies are isolated in a local requirements file for reproducibility. The transformer core is intentionally lightweight and open to extension.
+Dependencies are isolated in a local requirements file for reproducibility, and the project runs entirely on CPU without requiring PyTorch or GPU drivers. The transformer core is intentionally lightweight and open to extension.
 
 Developers may augment the pool of improvisational verbs to steer style.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-torch==2.2.1+cpu
-transformers==4.38.2
 python-telegram-bot==20.7

--- a/tripd_expansion.py
+++ b/tripd_expansion.py
@@ -20,7 +20,7 @@ _TRAIN_LOG = Path(__file__).resolve().parent / "training.log"
 
 def _train_on_scripts(scripts: Iterable[str]) -> None:
     """Pretend to fine‑tune a model on the provided scripts."""
-    # A realistic implementation would invoke torch/transformers here.
+    # A realistic implementation would invoke an external training library here.
     scripts = list(scripts)
     time.sleep(0.1)  # Simulate a bit of work.
     timestamp = datetime.now().isoformat()


### PR DESCRIPTION
## Summary
- Drop PyTorch and Transformers from requirements for a CPU-only setup
- Clarify in docs that the project runs without PyTorch or GPU drivers
- Generalize expansion module comment to avoid torch references

## Testing
- `python -m py_compile tripd_expansion.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b485442d408329815477a23ce40a31