### PR TITLE
Support standalone imports for TRIPD modules

### DIFF
--- a/tripd.py
+++ b/tripd.py
@@ -15,8 +15,12 @@ import math
 import random
 from typing import Dict, List
 
-from .tripd_memory import log_script, get_log_count
-from .tripd_expansion import train_async
+try:  # pragma: no cover - support running as a script
+    from .tripd_memory import log_script, get_log_count
+    from .tripd_expansion import train_async
+except ImportError:  # pragma: no cover - fallback to absolute imports
+    from tripd_memory import log_script, get_log_count
+    from tripd_expansion import train_async
 
 
 class ComplexAmplitudeSimulator:

--- a/tripd_expansion.py
+++ b/tripd_expansion.py
@@ -13,7 +13,10 @@ from typing import Iterable
 from datetime import datetime
 import time
 
-from .tripd_memory import load_scripts
+try:  # pragma: no cover - allow execution outside a package
+    from .tripd_memory import load_scripts
+except ImportError:  # pragma: no cover - fallback when run as script
+    from tripd_memory import load_scripts
 
 _TRAIN_LOG = Path(__file__).resolve().parent / "training.log"
 

--- a/tripd_tg.py
+++ b/tripd_tg.py
@@ -22,8 +22,12 @@ from telegram.ext import (
     filters,
 )
 
-from .tripd import TripDModel
-from .verb_stream import start_verb_stream
+try:  # pragma: no cover - support package and script execution
+    from .tripd import TripDModel
+    from .verb_stream import start_verb_stream
+except ImportError:  # pragma: no cover - fallback for running as scripts
+    from tripd import TripDModel
+    from verb_stream import start_verb_stream
 
 # ---------------------------------------------------------------------------
 # Model and dictionary setup

--- a/verb_stream.py
+++ b/verb_stream.py
@@ -7,7 +7,10 @@ import socket
 import threading
 from typing import Optional
 
-from .tripd import TripDModel  # type: ignore
+try:  # pragma: no cover - prefer package import
+    from .tripd import TripDModel  # type: ignore
+except ImportError:  # pragma: no cover - fallback when run directly
+    from tripd import TripDModel  # type: ignore
 
 
 def _handle_conn(conn: socket.socket, model: TripDModel) -> None:


### PR DESCRIPTION
## Summary
- allow TRIPD modules to fall back to absolute imports when executed outside a package
- enable verb streaming and telegram interface to run directly or as part of a package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4887f221c8329a5e7b30cba7f4298