### PR TITLE
Run telegram runner script directly

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: python -m tripd.tripd_tg
+worker: python tripd_tg.py

--- a/tripd_memory.py
+++ b/tripd_memory.py
@@ -1,12 +1,12 @@
-from __future__ import annotations
-
 """Utility functions for tracking generated TRIPD scripts.
 
 This module stores each produced script in a JSON lines log file so that
-scripts are never repeated.  The log also provides a simple count used by
+scripts are never repeated. The log also provides a simple count used by
 training routines to trigger periodic fine‑tuning once enough examples have
 been collected.
 """
+
+from __future__ import annotations
 
 from pathlib import Path
 import hashlib

--- a/tripd_tg.py
+++ b/tripd_tg.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Telegram interface for the TRIPD model."""
+
+from __future__ import annotations
 
 from pathlib import Path
 import argparse

--- a/verb_stream.py
+++ b/verb_stream.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Tiny socket server to stream verbs into a TripDModel instance."""
+
+from __future__ import annotations
 
 from pathlib import Path
 import socket


### PR DESCRIPTION
## Summary
- remove unintended `tripd` package and restore original script layout
- point Procfile to `tripd_tg.py` instead of module execution
- reorder module headers to satisfy linter expectations

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b489d5e0588329a03456461d75bf40