### PR TITLE
feat: allow passing Telegram token via CLI

### DIFF
--- a/tripd_tg.py
+++ b/tripd_tg.py
@@ -137,7 +137,15 @@ def main() -> None:
         metavar="ADDR",
         help="Enable live verb streaming via TCP port or UNIX socket path",
     )
+    parser.add_argument(
+        "--token",
+        help=(
+            "Telegram bot token. Overrides TELEGRAM_TOKEN environment "
+            "variable if provided."
+        ),
+    )
     args = parser.parse_args()
+
     if args.verb_stream:
         addr = args.verb_stream
         if addr.isdigit():
@@ -145,9 +153,11 @@ def main() -> None:
         else:
             start_verb_stream(_model, unix_socket=addr)
 
-    token = os.environ.get("TELEGRAM_TOKEN")
+    token = args.token or os.environ.get("TELEGRAM_TOKEN")
     if not token:
-        raise RuntimeError("TELEGRAM_TOKEN environment variable is required")
+        raise RuntimeError(
+            "Telegram token required via --token or TELEGRAM_TOKEN environment variable"
+        )
     application = (
         Application.builder()
         .token(token)


### PR DESCRIPTION
## Summary
- allow specifying Telegram token via `--token` option
- improve error message when token is missing

## Testing
- `pytest -q`
- `flake8 tripd_tg.py` *(fails: E203 whitespace before ':', E501 line too long)*
- `python -m py_compile tripd_tg.py`


------
https://chatgpt.com/codex/tasks/task_e_68b49388eac483298c6d8ad3f07de9fc