### PR TITLE
Echo metrics in Telegram handler

### DIFF
--- a/tests/test_tg_metrics.py
+++ b/tests/test_tg_metrics.py
@@ -1,0 +1,48 @@
+import importlib.util
+import sys
+from pathlib import Path
+import asyncio
+BASE = Path(__file__).resolve().parent.parent
+
+
+def _load(name: str, file: str):
+    spec = importlib.util.spec_from_file_location(name, BASE / file)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_load("tripd_pkg.tripd_memory", "tripd_memory.py")
+_load("tripd_pkg.tripd_expansion", "tripd_expansion.py")
+_load("tripd_pkg.tripd", "tripd.py")
+_load("tripd_pkg.verb_stream", "verb_stream.py")
+tg = _load("tripd_pkg.tripd_tg", "tripd_tg.py")
+_handle_message = tg._handle_message
+
+
+class DummyMessage:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.replies = []
+
+    async def reply_text(self, text: str, **kwargs) -> None:
+        self.replies.append(text)
+
+
+class DummyUpdate:
+    def __init__(self, text: str) -> None:
+        self.message = DummyMessage(text)
+
+
+class DummyContext:
+    pass
+
+
+def test_metrics_echoed_back():
+    update = DummyUpdate("abc")
+    context = DummyContext()
+    asyncio.run(_handle_message(update, context))
+    assert len(update.message.replies) == 2
+    assert "entropy" in update.message.replies[1]
+    assert "perplexity" in update.message.replies[1]

--- a/tripd_tg.py
+++ b/tripd_tg.py
@@ -123,6 +123,8 @@ async def _handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     else:
         formatted = f"<code>{text}</code>"
     await update.message.reply_text(formatted, parse_mode="HTML")
+    metrics_text = ", ".join(f"{k}: {v:.3f}" for k, v in metrics.items())
+    await update.message.reply_text(metrics_text)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Echo metrics back to users in Telegram client
- Add unit test verifying metrics are returned

## Testing
- `flake8 tripd_tg.py` *(fails: E203, E302, E501)*
- `flake8 tests/test_tg_metrics.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4987a83808329bc1e3938ad589b99