### PR TITLE
Refactor Telegram client to use TripDModel for message handling

### DIFF
--- a/tests/test_tg_metrics.py
+++ b/tests/test_tg_metrics.py
@@ -39,10 +39,11 @@ class DummyContext:
     pass
 
 
-def test_metrics_echoed_back():
+def test_script_and_metrics_returned():
     update = DummyUpdate("abc")
     context = DummyContext()
     asyncio.run(_handle_message(update, context))
     assert len(update.message.replies) == 2
+    assert "def tripd_script" in update.message.replies[0]
     assert "entropy" in update.message.replies[1]
     assert "perplexity" in update.message.replies[1]

--- a/tripd_tg.py
+++ b/tripd_tg.py
@@ -110,20 +110,15 @@ async def _send_theory(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
 
 # ---------------------------------------------------------------------------
-# Message echo with metric-based font selection
+# Message handling delegated to the TRIPD model
 async def _handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     assert update.message
     text = update.message.text or ""
     logger.info("Received message: %s", text)
-    metrics = _model.metrics(text)
-    if metrics["entropy"] > 4.5:
-        formatted = f"<b>{text}</b>"
-    elif metrics["perplexity"] > 10:
-        formatted = f"<i>{text}</i>"
-    else:
-        formatted = f"<code>{text}</code>"
-    await update.message.reply_text(formatted, parse_mode="HTML")
-    metrics_text = ", ".join(f"{k}: {v:.3f}" for k, v in metrics.items())
+    script, metrics_text = _model.generate_response(text)
+    await update.message.reply_text(
+        f"```python\n{script}\n```", parse_mode="Markdown"
+    )
     await update.message.reply_text(metrics_text)
 
 


### PR DESCRIPTION
## Summary
- centralize message processing in TripDModel with new `generate_response` API
- delegate Telegram bot message handler to TripDModel, returning scripts and metrics
- update tests to validate script generation and metrics output

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b0364ea483298f759561d046619c