### PR TITLE
feat: dynamic script naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A bundled tripdictionary enumerates verbs that shape perception across diverse d
 
 On startup the model reads this dictionary to form its initial phrase repertoire. It also improvises with an internal pool of verbs to maintain semantic drift. Incoming messages are analysed for entropy, resonance, and perplexity. These metrics determine which dictionary section will guide the script.
 
-Generated scripts conform to Python syntax while carrying tripd's surreal verbs. The memory module ensures that a script is never produced twice. Logged outputs accumulate as JSON lines for transparent review. After every five unique scripts the system triggers a background training pass.
+Generated scripts conform to Python syntax while carrying tripd's surreal verbs. Function names weave in message metrics and the current log count, so each script arrives with a unique signature. The memory module ensures that a script is never produced twice. Logged outputs accumulate as JSON lines for transparent review. After every five unique scripts the system triggers a background training pass.
 
 Training is asynchronous so user interaction remains responsive. The expansion module currently simulates fine-tuning and records its activity. A real deployment could integrate a lightweight trainer if deeper learning is desired.
 

--- a/tests/test_tg_metrics.py
+++ b/tests/test_tg_metrics.py
@@ -44,6 +44,6 @@ def test_script_and_metrics_returned():
     context = DummyContext()
     asyncio.run(_handle_message(update, context))
     assert len(update.message.replies) == 2
-    assert "def tripd_script" in update.message.replies[0]
+    assert "def tripd_" in update.message.replies[0]
     assert "entropy" in update.message.replies[1]
     assert "perplexity" in update.message.replies[1]

--- a/tripd.py
+++ b/tripd.py
@@ -157,7 +157,9 @@ class TripDModel:
             commands += random.sample(pool, 4 - k)
         extra = random.sample(self.extra_verbs, max(1, len(commands) // 5))
         lines = [f"    {cmd}" for cmd in commands + extra]
-        script = "def tripd_script():\n" + "\n".join(lines) + "\n"
+        selector = int(metrics["selector"])
+        func_name = f"tripd_{selector}_{get_log_count()}"
+        script = f"def {func_name}():\n" + "\n".join(lines) + "\n"
 
         log_script(script)
         if get_log_count() % 5 == 0:
@@ -176,7 +178,9 @@ class TripDModel:
             commands += random.sample(pool, 4 - k)
         extra = random.sample(self.extra_verbs, max(1, len(commands) // 5))
         lines = [f"    {cmd}" for cmd in commands + extra]
-        script = "def tripd_script():\n" + "\n".join(lines) + "\n"
+        safe = "".join(ch if ch.isalnum() or ch == "_" else "_" for ch in section)
+        func_name = f"tripd_{safe}_{get_log_count()}"
+        script = f"def {func_name}():\n" + "\n".join(lines) + "\n"
 
         log_script(script)
         if get_log_count() % 5 == 0:

--- a/tripd_tg.py
+++ b/tripd_tg.py
@@ -79,7 +79,7 @@ async def _send_section(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     logger.info("Section requested: %s", section)
     script = _model.generate_from_section(section)
     await query.edit_message_text(
-        f"```python\n{script}\n```", parse_mode="Markdown"
+        f"```TRIPD\n{script}\n```", parse_mode="Markdown"
     )
 
 
@@ -117,7 +117,7 @@ async def _handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     logger.info("Received message: %s", text)
     script, metrics_text = _model.generate_response(text)
     await update.message.reply_text(
-        f"```python\n{script}\n```", parse_mode="Markdown"
+        f"```TRIPD\n{script}\n```", parse_mode="Markdown"
     )
     await update.message.reply_text(metrics_text)
 


### PR DESCRIPTION
## Summary
- send TRIPD-tagged code fences in Telegram replies
- derive unique function names from message metrics and section data
- document and test dynamic naming behavior

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68b4b844af248329b17e3625ad90a530