### PR TITLE
Ensure unique TRIPD script generation

### DIFF
--- a/tests/test_unique_generation.py
+++ b/tests/test_unique_generation.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from tripd import TripDModel
+
+
+def test_generate_script_retries_on_duplicate(monkeypatch):
+    model = TripDModel()
+    call_count = {"count": 0}
+
+    def fake_log_script(script: str) -> bool:
+        call_count["count"] += 1
+        return call_count["count"] > 1
+
+    monkeypatch.setattr("tripd_memory.log_script", fake_log_script)
+    monkeypatch.setattr("tripd.log_script", fake_log_script)
+    monkeypatch.setattr("tripd.train_async", lambda: None)
+
+    model.generate_script("hello world")
+
+    assert call_count["count"] >= 2

--- a/tripd.py
+++ b/tripd.py
@@ -150,16 +150,20 @@ class TripDModel:
         """
         metrics = metrics or self.metrics(message)
         section = self._choose_section(metrics)
-        k = min(4, len(self.sections[section]))
-        commands = self.simulator.sample(self.sections[section], k)
-        if k < 4:
-            pool = [cmd for cmd in self.all_commands if cmd not in commands]
-            commands += random.sample(pool, 4 - k)
-        extra = random.sample(self.extra_verbs, max(1, len(commands) // 5))
-        lines = [f"    {cmd}" for cmd in commands + extra]
-        script = "def tripd_script():\n" + "\n".join(lines) + "\n"
-
-        log_script(script)
+        max_attempts = 5
+        attempt = 0
+        while True:
+            k = min(4, len(self.sections[section]))
+            commands = self.simulator.sample(self.sections[section], k)
+            if k < 4:
+                pool = [cmd for cmd in self.all_commands if cmd not in commands]
+                commands += random.sample(pool, 4 - k)
+            extra = random.sample(self.extra_verbs, max(1, len(commands) // 5))
+            lines = [f"    {cmd}" for cmd in commands + extra]
+            script = "def tripd_script():\n" + "\n".join(lines) + "\n"
+            if log_script(script) or attempt >= max_attempts - 1:
+                break
+            attempt += 1
         if get_log_count() % 5 == 0:
             train_async()
         return script
@@ -169,16 +173,20 @@ class TripDModel:
         """Create a TRIPD script using commands from a specific section."""
         if section not in self.sections:
             raise KeyError(f"Unknown section: {section}")
-        k = min(4, len(self.sections[section]))
-        commands = self.simulator.sample(self.sections[section], k)
-        if k < 4:
-            pool = [cmd for cmd in self.all_commands if cmd not in commands]
-            commands += random.sample(pool, 4 - k)
-        extra = random.sample(self.extra_verbs, max(1, len(commands) // 5))
-        lines = [f"    {cmd}" for cmd in commands + extra]
-        script = "def tripd_script():\n" + "\n".join(lines) + "\n"
-
-        log_script(script)
+        max_attempts = 5
+        attempt = 0
+        while True:
+            k = min(4, len(self.sections[section]))
+            commands = self.simulator.sample(self.sections[section], k)
+            if k < 4:
+                pool = [cmd for cmd in self.all_commands if cmd not in commands]
+                commands += random.sample(pool, 4 - k)
+            extra = random.sample(self.extra_verbs, max(1, len(commands) // 5))
+            lines = [f"    {cmd}" for cmd in commands + extra]
+            script = "def tripd_script():\n" + "\n".join(lines) + "\n"
+            if log_script(script) or attempt >= max_attempts - 1:
+                break
+            attempt += 1
         if get_log_count() % 5 == 0:
             train_async()
         return script

--- a/tripd_memory.py
+++ b/tripd_memory.py
@@ -79,21 +79,23 @@ def load_scripts() -> List[str]:
     return list(_SCRIPT_LIST)
 
 
-def log_script(script: str) -> None:
+def log_script(script: str) -> bool:
     """Persist *script* if it has not been seen before.
 
+    Returns ``True`` if the script was newly logged and ``False`` otherwise.
     Membership checks are serviced entirely from the in-memory index so the
     log file is not re-read on each call.
     """
     script_hash = _hash_script(script)
     if script_hash in _SCRIPTS_INDEX:
-        return
+        return False
     _ensure_log()
     _rotate_log()
     with _LOG_PATH.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps({"hash": script_hash, "script": script}) + "\n")
     _SCRIPTS_INDEX.add(script_hash)
     _SCRIPT_LIST.append(script)
+    return True
 
 
 def get_log_count() -> int:


### PR DESCRIPTION
## Summary
- Make `log_script` return a boolean indicating whether a script was newly logged
- Retry TRIPD script generation until `log_script` reports uniqueness or a retry limit is hit
- Add test confirming the generator retries when a duplicate script is detected

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b88712548329beab88ffb1c3438a