### PR TITLE
feat: refine TRIPD menu text

### DIFF
--- a/tests/test_show_menu.py
+++ b/tests/test_show_menu.py
@@ -1,0 +1,83 @@
+import importlib.util
+import sys
+from pathlib import Path
+import asyncio
+
+from telegram import InlineKeyboardMarkup
+
+BASE = Path(__file__).resolve().parent.parent
+
+
+def _load(name: str, file: str):
+    spec = importlib.util.spec_from_file_location(name, BASE / file)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_load("tripd_pkg.tripd_memory", "tripd_memory.py")
+_load("tripd_pkg.tripd_expansion", "tripd_expansion.py")
+_load("tripd_pkg.tripd", "tripd.py")
+_load("tripd_pkg.verb_stream", "verb_stream.py")
+tg = _load("tripd_pkg.tripd_tg", "tripd_tg.py")
+_show_menu = tg._show_menu
+
+
+class DummyMessage:
+    def __init__(self):
+        self.replies = []
+
+    async def reply_text(self, text: str, **kwargs):
+        self.replies.append((text, kwargs))
+
+
+class DummyCallbackQuery:
+    def __init__(self):
+        self.answered = False
+        self.edits = []
+
+    async def answer(self):
+        self.answered = True
+
+    async def edit_message_text(self, text: str, **kwargs):
+        self.edits.append((text, kwargs))
+
+
+class DummyUpdateCommand:
+    def __init__(self):
+        self.message = DummyMessage()
+        self.callback_query = None
+
+
+class DummyUpdateCallback:
+    def __init__(self):
+        self.message = None
+        self.callback_query = DummyCallbackQuery()
+
+
+class DummyContext:
+    pass
+
+
+def test_show_menu_command():
+    update = DummyUpdateCommand()
+    asyncio.run(_show_menu(update, DummyContext()))
+    assert update.message.replies
+    text, kwargs = update.message.replies[0]
+    assert text == "Choose a TRIPD section:"
+    markup = kwargs.get("reply_markup")
+    assert isinstance(markup, InlineKeyboardMarkup)
+    assert markup.inline_keyboard
+
+
+def test_show_menu_callback():
+    update = DummyUpdateCallback()
+    asyncio.run(_show_menu(update, DummyContext()))
+    assert update.callback_query.answered
+    assert update.callback_query.edits
+    text, kwargs = update.callback_query.edits[0]
+    assert text == "Choose a TRIPD section:"
+    markup = kwargs.get("reply_markup")
+    assert isinstance(markup, InlineKeyboardMarkup)
+    assert markup.inline_keyboard

--- a/tripd_tg.py
+++ b/tripd_tg.py
@@ -58,14 +58,15 @@ def _menu_keyboard() -> InlineKeyboardMarkup:
 
 
 async def _show_menu(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    message = "Choose a TRIPD section:"
     if update.callback_query:
         await update.callback_query.answer()
         await update.callback_query.edit_message_text(
-            "Select a topic:", reply_markup=_menu_keyboard()
+            message, reply_markup=_menu_keyboard()
         )
     else:
         await update.message.reply_text(
-            "Select a topic:", reply_markup=_menu_keyboard()
+            message, reply_markup=_menu_keyboard()
         )
     logger.info("Menu displayed")
 


### PR DESCRIPTION
## Summary
- replace generic Telegram menu prompt with TRIPD-specific wording
- add tests confirming menu keyboard for command and callback use

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4bc039dd88329b4ffca9edfc3e6c9