### PR TITLE
Send TRIPD sections as new messages

### DIFF
--- a/tripd_tg.py
+++ b/tripd_tg.py
@@ -78,7 +78,7 @@ async def _send_section(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     section = query.data.split(":", 1)[1]
     logger.info("Section requested: %s", section)
     script = _model.generate_from_section(section)
-    await query.edit_message_text(
+    await query.message.reply_text(
         f"```TRIPD\n{script}\n```", parse_mode="Markdown"
     )
 


### PR DESCRIPTION
## Summary
- Preserve the TRIPD topic menu by replying with section content instead of editing the menu message.

## Testing
- `flake8 tripd_tg.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b9d894bc8329a1357bc62d894687